### PR TITLE
Optional error raise

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -1,1 +1,8 @@
 inherit_from: .rubocop_u2i.yml
+
+AllCops:
+  TargetRubyVersion: 1.9
+
+Style/RescueModifier:
+  Exclude:
+  - spec/**/*_spec.rb

--- a/.travis.yml
+++ b/.travis.yml
@@ -3,6 +3,7 @@ env:
 language: ruby
 rvm:
   - 1.9.3
-  - 2.1.5
-  - 2.2.1
+  - 2.1
+  - 2.2
+  - 2.3.0
   - jruby-19mode

--- a/lib/rails_config_validator/railtie.rb
+++ b/lib/rails_config_validator/railtie.rb
@@ -3,6 +3,7 @@ module RailsConfigValidator
     config.before_configuration do
       config.config_validator = ActiveSupport::OrderedOptions.new
       config.config_validator.configs %w(database)
+      config.config_validator.raise_errors true
     end
 
     rake_tasks do
@@ -12,8 +13,9 @@ module RailsConfigValidator
     end
 
     initializer 'config_validator.configure' do
+      raise_errors = config.config_validator.raise_errors
       validators = config.config_validator.configs.map do |config|
-        RailsConfigValidator::Validator.new(config, Rails.env, pwd: Rails.root)
+        RailsConfigValidator::Validator.new(config, Rails.env, pwd: Rails.root, raise_errors: raise_errors)
       end
 
       validators.each(&:valid!)

--- a/lib/rails_config_validator/rake_task.rb
+++ b/lib/rails_config_validator/rake_task.rb
@@ -32,7 +32,7 @@ module RailsConfigValidator
       task :validate, [:config, :env] do |_, args|
         config = args[:config]
         env = args[:env] || Rails.env
-        fail 'Missing parameter :config' if args[:config].nil?
+        raise 'Missing parameter :config' if args[:config].nil?
 
         v = RailsConfigValidator::Validator.new(config, env, pwd: Rails.root)
         v.valid!

--- a/lib/rails_config_validator/version.rb
+++ b/lib/rails_config_validator/version.rb
@@ -1,3 +1,3 @@
 module RailsConfigValidator
-  VERSION = '3.1.2'
+  VERSION = '3.1.2'.freeze
 end

--- a/rails_config_validator.gemspec
+++ b/rails_config_validator.gemspec
@@ -27,7 +27,7 @@ Gem::Specification.new do |spec|
 
   spec.add_development_dependency 'bundler', '~> 1.7'
   spec.add_development_dependency 'rake', '~> 10.0'
-  spec.add_development_dependency 'u2i-ci_utils', '~> 2.0'
+  spec.add_development_dependency 'u2i-ci_utils', '~> 3.0'
 
   spec.add_development_dependency 'guard-rubocop', '~> 1.2'
   spec.add_development_dependency 'guard-rspec', '~> 4.5'


### PR DESCRIPTION
Allow to configure Rails Config Validator to show warnings instead of raising exceptions.
